### PR TITLE
increase the pagesize for the allowed values store

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio-item-url-shared-views",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "scripts": {
     "debug": "grunt debug",
     "debug:watch": "nodemon --exec grunt debug",

--- a/src/javascript/utils/overrides.js
+++ b/src/javascript/utils/overrides.js
@@ -23,6 +23,25 @@ Rally.ui.renderer.GridEditorFactory.editorRenderers['PreliminaryEstimate'] = fun
     };
 };
 
+Ext.override(Rally.data.wsapi.Field, {
+    getAllowedValueStore: function(storeConfig) {
+        var allowedValues = this._getAllowedValues();
+        if (allowedValues) {
+            if(!this._allowedValueStore) {
+                this._allowedValueStore = Ext.create('Rally.data.wsapi.collection.Store', _.merge({
+                    cacheResults: true,
+                    initialCount: allowedValues.length || allowedValues.Count,
+                    model: Ext.identityFn('AllowedAttributeValue'),
+                    proxy: Rally.data.wsapi.ModelFactory.buildProxy(this.getAllowedValuesRef(), this.name),
+                    pageSize: 2000
+                }, storeConfig));
+            }
+            return this._allowedValueStore;
+        }
+        return null;
+    }
+});
+
 Ext.override(Rally.nav.Manager, {
     // Override to not automatically remove other parameters
     applyParameters: function(params, triggerNavStateChange, paramsToRemove) {


### PR DESCRIPTION
Why?

- Drop Downs for custom fields with many allowed values sometimes did not select their value on the initial page load if the selected value was not in the first page of results returned from the API

What?

- Increase the pagesize from 200 to 2000, reducing the likelihood that users will run into the issue
